### PR TITLE
NEW Exposing access to opauth config

### DIFF
--- a/_config/_config.yml
+++ b/_config/_config.yml
@@ -6,9 +6,10 @@ After: 'framework/*','cms/*'
 # See http://doc.silverstripe.org/framework/en/topics/configuration
 # Caution: Indentation through two spaces, not tabs
 OpauthAuthenticator:
-  opauth_security_iteration: 500
-  opauth_security_timeout: '2 minutes'
-  opauth_callback_transport: 'session'
+  opauth_settings:
+    security_iteration: 500
+    security_timeout: '2 minutes'
+    callback_transport: 'session'
 Member:
   has_many:
     OpauthIdentities: OpauthIdentity

--- a/code/OpauthAuthenticator.php
+++ b/code/OpauthAuthenticator.php
@@ -14,9 +14,9 @@ class OpauthAuthenticator extends MemberAuthenticator {
 		 */
 		$enabled_strategies = array(),
 		/**
-		 * @config string
+		 * @config array The opauth settings array
 		 */
-		$opauth_security_salt,
+		$opauth_settings = array(),
 		/**
 		 * @var Opauth Persistent Opauth instance.
 		 */
@@ -41,12 +41,8 @@ class OpauthAuthenticator extends MemberAuthenticator {
 			array(
 				'path' => OpauthController::get_path(),
 				'callback_url' => OpauthController::get_callback_path(),
-				'security_salt' => $config->opauth_security_salt,
-				'security_iteration' => $config->opauth_security_iteration,
-				'security_timeout' => $config->opauth_security_timeout,
-				'callback_transport' => $config->opauth_callback_transport,
-				'Strategy' => $config->opauth_strategy_config,
 			),
+			$config->opauth_settings,
 			$mergeConfig
 		);
 	}

--- a/docs/en/configuration/index.md
+++ b/docs/en/configuration/index.md
@@ -46,3 +46,9 @@ Config::inst()->update('OpauthAuthenticator', 'opauth_strategy_config', array(
 	)
 ));
 ```
+
+## Configuring Opauth
+
+As you can see, Opauth takes its own config options, these are set by...
+
+Some of the settings are redundant, such as `strategy_dir` as SilverStripe will auto load the strategies for you.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -37,10 +37,10 @@ You can find them under the "Available Strategies" heading on the [Opauth homepa
 Alternatively, you can find them in the [bundle package](http://opauth.org/download.php).
 
 ### Where should I put strategies?
-We recommend putting them under `mysite/code/thirdparty`, but it's up to you. Any root level directory that contains a `_config.php` (empty or otherwise) is scanned by the manifest builder.
+We recommend putting them under `mysite/thirdparty`, but it's up to you. Any root level directory that contains a `_config.php` (empty or otherwise) is scanned by the manifest builder.
 
-### Why isn't SilverStripe finding my stratagies in `mysite/code/thirdparty`?
-It could be you're super clever and have a `_manifest_exclude` file in your `thirdparty` folder, preventing it being spidered by SilverStripe's manifest builder. Try moving the stratagies folder to mysite/code/opauth/
+### Why isn't SilverStripe finding my stratagies in `mysite/thirdparty`?
+It could be you're super clever and have a `_manifest_exclude` file in your `thirdparty` folder, preventing it being spidered by SilverStripe's manifest builder. Try moving the stratagies folder to `mysite/code/opauth/` or, if you don't want to do that, you can set the opauth setting `strategy_dir` to be `BASE_PATH . '/mysite/thirdparty'` and Opauth will find them for you.
 
 ### How do I map the API responses to a `Member`?
 You define the `OpauthIdentity` `member_mapper` block in your `_config.yml`. Simply provide a hash map of member fields to dot notated paths of the Opauth response array for simple fields, or if you need to perform some parsing to retrieve the value you want, an array of class name and function, like `['OpauthResponseHelper', 'get_first_name']`. It takes the auth response array as an argument. See the example config YAML below for more details.


### PR DESCRIPTION
At the moment, to change opauth config settings, we have to expose them
via the authenticator class and pass them through to Opauth.

This change allows the dev to directly set the opauth config, giving
them much better control and making it more transparent.

We're going to align better with Opauth's docs and convention if we do
this.
