### PR TITLE
Updating composer.json to install module into "opauth" directory.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
 	],
 	"require": {
 		"php": ">=5.3.0"
+	},
+	"extra" : {
+		"installer-name": "opauth"
 	}
 }


### PR DESCRIPTION
Instead of installing it in the "silverstripe-opauth" directory, this
changes Composer to install it in the "opauth" directory, which matches
the other SilverStripe modules out there.

Wasn't sure which branch this pull request should go against, so chose master :)
