### PR TITLE
Allow disabling of "forgot password" feature

### DIFF
--- a/_config/_config.yml
+++ b/_config/_config.yml
@@ -13,3 +13,6 @@ OpauthAuthenticator:
 Member:
   has_many:
     OpauthIdentities: OpauthIdentity
+MemberLoginForm:
+  extensions:
+    - OpauthMemberLoginFormExtension

--- a/code/OpauthMemberLoginFormExtension.php
+++ b/code/OpauthMemberLoginFormExtension.php
@@ -1,0 +1,37 @@
+<?php
+class OpauthMemberLoginFormExtension extends Extension {
+
+	/**
+	 * @config
+	 * @var boolean
+	 */
+	private static $allow_password_reset = true;
+
+	/**
+	 * Deny password resets
+	 * 
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function forgotPassword($member) {
+		if(Config::inst()->get('OpauthMemberLoginFormExtension', 'allow_password_reset')) {
+			return null;
+		}
+
+		$identity = OpauthIdentity::get()->find('MemberID', $member->ID);
+		if(!$member->Password && $identity) {
+			$this->owner->sessionMessage(
+				_t(
+					'OpauthMemberLoginFormExtension.NoResetPassword',
+					'Can\'t reset password for accounts registered through {provider}',
+					array('provider' => $identity->Provider)
+				),
+				'bad'
+			);
+			return false;
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/docs/en/configuration/index.md
+++ b/docs/en/configuration/index.md
@@ -65,3 +65,6 @@ If you wish to run some special logic at certain points of the authentication pr
 
 The extension points can be accessed using the standard SilverStripe DataExtension system, and should cover a lot of use cases where special business logic must happen.
 Since you can access the full object on the extended event, you can even customise your logic based on the identity provider for this request.
+
+#### OpauthMemberLoginFormExtension
+* `allow_password_reset`: Config setting to disable password resets for `Member` records which are linked with an identity provider (requires SilverStripe 3.1.4 or newer)

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -8,3 +8,5 @@ en:
   OpauthController:
     TITLE: 'Social login'
     PROFILECOMPLETIONTITLE: 'Complete your profile to register'
+  OpauthMemberLoginFormExtension:
+    NoResetPassword: 'Can''t reset password for accounts registered through {provider}'

--- a/tests/unit/OpauthMemberLoginFormExtensionTest.php
+++ b/tests/unit/OpauthMemberLoginFormExtensionTest.php
@@ -1,0 +1,40 @@
+<?php
+class OpauthMemberLoginFormExtensionTest extends SapphireTest {
+
+	public function testForgotPasswordVeto() {
+		$memberWithoutPassword = new Member(array(
+			'Email' => 'withoutpassword@test.com'
+		));
+		$memberWithoutPassword->write();
+
+		$memberWithPassword = new Member(array(
+			'Email' => 'withpassword@test.com',
+			'Password' => 'test'
+		));
+		$memberWithPassword->write();
+
+		$memberWithIdentity = new Member(array(
+			'Email' => 'withidentity@test.com',
+		));
+		$memberWithIdentity->write();
+		$identity = new OpauthIdentity(array(
+			'MemberID' => $memberWithIdentity->ID,
+			'Provider' => 'Google'
+		));
+		$identity->write();
+
+		$form = new Form(new Controller(), 'Form', new FieldList(), new FieldList());
+		$ext = new OpauthMemberLoginFormExtension();
+		$ext->setOwner($form);
+
+		$this->assertNull($ext->forgotPassword($memberWithoutPassword));
+		$this->assertNull(Session::get("FormInfo.Form_Form.formError.message"));
+		
+		$this->assertNull($ext->forgotPassword($memberWithPassword));
+		$this->assertNull(Session::get("FormInfo.Form_Form.formError.message"));
+		
+		$this->assertFalse($ext->forgotPassword($memberWithIdentity));
+		$this->assertContains('Google', Session::get("FormInfo.Form_Form.formError.message"));
+	}
+
+}


### PR DESCRIPTION
Gives the site a bit more control over the paths on which
a user can switch from an identity provider to a password-based login.

Requires https://github.com/silverstripe/silverstripe-framework/pull/2893 to be merged.
