### PR TITLE
Set OpauthIdentityID session regardless of valid()

### DIFF
--- a/code/OpauthController.php
+++ b/code/OpauthController.php
@@ -137,11 +137,12 @@ class OpauthController extends ContentController {
 			// Write the identity
 			$identity->write();
 
+			// Keep a note of the identity ID
+			Session::set('OpauthIdentityID', $identity->ID);
+
 			// Even if written, check validation - we might not have full fields
 			$validationResult = $member->validate();
 			if(!$validationResult->valid()) {
-				// Keep a note of the identity ID
-				Session::set('OpauthIdentityID', $identity->ID);
 				// Set up the register form before it's output
 				$regForm = $this->RegisterForm();
 				$regForm->loadDataFrom($member);


### PR DESCRIPTION
This ensures the loginAndRedirect() target can respond appropriately if a
member is valid, but can't log in yet. The specific use case is a member
record which needs to be verified by email confirmation until they can log in.
