### PR TITLE
opauth_path doesn't work for second-level project directories.

### DIFF
--- a/_config/_routes.yml
+++ b/_config/_routes.yml
@@ -5,7 +5,7 @@ After: framework/routes#rootroutes
 # Config weirdness - confusing.
 # Remember to replicate this path with no slashes in the Director rules.
 OpauthController:
-  opauth_path: '/opauth/'
+  opauth_path: 'opauth/'
 Director:
   rules:
     'opauth/strategy/$Strategy/$StrategyMethod': 'OpauthController'


### PR DESCRIPTION
This would fail if your site was at http://localhost/ss3, the path would
resolve to http://localhost/opauth/ because of the prefixed slash.
