### PR TITLE
Fixed forgot password tests

### DIFF
--- a/tests/unit/OpauthMemberLoginFormExtensionTest.php
+++ b/tests/unit/OpauthMemberLoginFormExtensionTest.php
@@ -2,6 +2,8 @@
 class OpauthMemberLoginFormExtensionTest extends SapphireTest {
 
 	public function testForgotPasswordVeto() {
+		Config::inst()->update('OpauthMemberLoginFormExtension', 'allow_password_reset', false);
+
 		$memberWithoutPassword = new Member(array(
 			'Email' => 'withoutpassword@test.com'
 		));


### PR DESCRIPTION
Was passing in a project install because the value was configured
as false there - but not in a standard 3.1 install.
