### PR TITLE
ENHANCEMENT Allows for replacement of the default form.

### DIFF
--- a/code/OpauthController.php
+++ b/code/OpauthController.php
@@ -349,8 +349,9 @@ class OpauthController extends ContentController {
 	protected function handleOpauthException(OpauthValidationException $e) {
 		$data = $e->getData();
 		
-		$form = OpauthLoginForm::create($this, FieldList::create(), FieldList::create());
-		$loginFormName = get_class($form);
+		$attr = OpauthLoginForm::create($this, 'OpauthLoginForm', FieldList::create(), FieldList::create())
+			->getAttributes();
+		$loginFormName = $attr['id'];
 		$message = '';
 		
 		switch($e->getCode()) {


### PR DESCRIPTION
At the moment, if you extend OpauthLoginForm you won't see any error messages generated here.

This fix allows devs to override the default form and keep error messages intact.
