### PR TITLE
Adds a response controller to OpauthController for the profilecompletion endpoint

### DIFF
--- a/code/OpauthController.php
+++ b/code/OpauthController.php
@@ -52,6 +52,23 @@ class OpauthController extends ContentController {
 	}
 
 	/**
+	 * Prepare the controller for handling the response to this request
+	 *
+	 * @param string $title Title to use
+	 * @return Controller
+	 */
+	protected function getResponseController($title) {
+		if(!class_exists('SiteTree')) return $this;
+
+		// Use sitetree pages to render the opauth pages
+		$tmpPage = new Page();
+		
+		$controller = Page_Controller::create($tmpPage);
+		$controller->init();
+		return $controller;
+	}
+
+	/**
 	 * This function only catches the request to pass it straight on.
 	 * Opauth uses the last segment of the URL to identify the auth method.
 	 * In _routes.yml we enforce a $Strategy request parameter to enforce this.
@@ -212,6 +229,9 @@ class OpauthController extends ContentController {
 	}
 
 	public function profilecompletion(SS_HTTPRequest $request = null) {
+		// Get response handler
+		$controller = $this->getResponseController(_t('Opauth.PROFILECOMPLETIONTITLE', 'Complete your profile'));
+		
 		if(!Session::get('OpauthIdentityID')) {
 			Security::permissionFailure($this);
 		}

--- a/code/OpauthController.php
+++ b/code/OpauthController.php
@@ -62,6 +62,8 @@ class OpauthController extends ContentController {
 
 		// Use sitetree pages to render the opauth pages
 		$tmpPage = new Page();
+		$tmpPage->ID = -1;
+		$tmpPage->Title = $title;
 		
 		$controller = ModelAsController::controller_for($tmpPage);
 		$controller->init();

--- a/code/OpauthController.php
+++ b/code/OpauthController.php
@@ -63,7 +63,7 @@ class OpauthController extends ContentController {
 		// Use sitetree pages to render the opauth pages
 		$tmpPage = new Page();
 		
-		$controller = Page_Controller::create($tmpPage);
+		$controller = ModelAsController::controller_for($tmpPage);
 		$controller->init();
 		return $controller;
 	}


### PR DESCRIPTION
Updated to use `ModelAsController::controller_for($tmpPage);` as per #38 
